### PR TITLE
add checker for duplicate server_names

### DIFF
--- a/Parser.hpp
+++ b/Parser.hpp
@@ -9,6 +9,7 @@
 # include <unistd.h>
 # include <vector>
 # include <stdexcept>
+# include <algorithm>
 
 class Server;
 
@@ -37,6 +38,7 @@ class Parser {
         Location    &parse_location(std::string &location_block, Location &location);
         void        set_server_directives(std::string &key, std::string &value, Server &server);
         void        set_location_directives(std::string &key, std::string &value, Location &location);
+        void        check_duplicate_server_names();
 };
 
 #endif

--- a/Server.cpp
+++ b/Server.cpp
@@ -241,28 +241,28 @@ void    Server::set_sock_fd() {
 
 const std::vector<Listen>&     Server::get_listeners() const {return _listeners;}
 
-std::string     Server::get_root() {return _root;}
+std::string&     Server::get_root() {return _root;}
 
 long    Server::get_client_max_body_size() {return _client_max_body_size;}
 
-std::string    Server::get_autoindex() {return _autoindex;}
+std::string&    Server::get_autoindex() {return _autoindex;}
 
-std::vector<std::string>     Server::get_server_name() {return _server_name;}
+std::vector<std::string>&     Server::get_server_name() {return _server_name;}
 
-std::vector<std::string>    Server::get_index() {return _index;}
+std::vector<std::string>&    Server::get_index() {return _index;}
 
-std::map<int, std::string>  Server::get_error_pages() {return _error_pages;}
+std::map<int, std::string>&  Server::get_error_pages() {return _error_pages;}
 
-std::string                 Server::get_error_page_path(int error_code) {
+std::string                  Server::get_error_page_path(int error_code) {
     std::map<int, std::string>::iterator it = _error_pages.find(error_code);
     if (it == _error_pages.end())
         return NULL;
     return it->second;
 }
 
-std::vector<std::string>    Server::get_methods() {return _methods;}
+std::vector<std::string>&    Server::get_methods() {return _methods;}
 
-std::vector<Location>    Server::get_location() {return _locations;}
+std::vector<Location>&    Server::get_location() {return _locations;}
 
 const std::vector<int>& Server::get_sock_fd() const {return _sock_fd;}
 

--- a/Server.hpp
+++ b/Server.hpp
@@ -41,15 +41,15 @@ class Server {
 
         //getters
         const std::vector<Listen>&  get_listeners() const;
-        std::string                 get_root();
+        std::string&                get_root();
         long                        get_client_max_body_size(); //in bytes
-        std::string                 get_autoindex();
-        std::vector<std::string>    get_server_name();
-        std::vector<std::string>    get_index();
-        std::map<int, std::string>  get_error_pages();
+        std::string&                get_autoindex();
+        std::vector<std::string>&   get_server_name();
+        std::vector<std::string>&   get_index();
+        std::map<int, std::string>& get_error_pages();
         std::string                 get_error_page_path(int error_code);
-        std::vector<std::string>    get_methods();
-        std::vector<Location>       get_location();
+        std::vector<std::string>&   get_methods();
+        std::vector<Location>&      get_location();
         const std::vector<int>&     get_sock_fd() const;
 
         void    check_port(std::string port);


### PR DESCRIPTION
Adicionei um checker no parser que percorre todos os servers checando server_names repetidos quando os servers ouvem na mesma porta