### PR TITLE
Feat/parse timeout

### DIFF
--- a/Location.hpp
+++ b/Location.hpp
@@ -1,9 +1,12 @@
 #ifndef LOCATION_HPP
 # define LOCATION_HPP
+# include "defines.hpp"
 # include <iostream>
-#include <map>
-#include <vector>
-#include <sys/stat.h>
+# include <map>
+# include <vector>
+# include <sys/stat.h>
+# include <climits>
+
 
 class Location {
     public:
@@ -16,6 +19,7 @@ class Location {
         void    set_root(std::string root);
         void    set_alias(std::string alias);
         void    set_client_max_body_size(std::string client_max_body_size);
+        void    set_timeout(std::string timeout);
         void    set_autoindex(std::string autoindex);
         void    set_index(std::string index);
         void    set_error_page(std::string error_pages);
@@ -29,6 +33,7 @@ class Location {
         std::string&                get_root();
         std::string&                get_alias();
         long                        get_client_max_body_size();
+        int                         get_timeout(); // in seconds
         std::string&                get_autoindex();
         std::vector<std::string>&   get_index();
         std::map<int, std::string>& get_error_pages();
@@ -47,6 +52,7 @@ class Location {
         std::string                 _root;
         std::string                 _alias;
         long                        _client_max_body_size;
+        int                         _timeout;
         std::string                 _autoindex;
         std::vector<std::string>    _index;
         std::vector<std::string>    _methods;

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -138,6 +138,8 @@ void    Parser::set_server_directives(std::string &key, std::string &value, Serv
         server.set_root(value);
     else if (key == "client_max_body_size")
         server.set_client_max_body_size(value);
+    else if (key == "keepalive_timeout")
+        server.set_timeout(value);
     else if (key == "server_name")
         server.set_server_name(value);
     else if (key == "index")
@@ -163,6 +165,8 @@ void    Parser::set_location_directives(std::string &key, std::string &value, Lo
         location.set_alias(value);
     else if (key == "client_max_body_size")
         location.set_client_max_body_size(value);
+    else if (key == "keepalive_timeout")
+        location.set_timeout(value);
     else if (key == "index")
         location.set_index(value);
     else if (key == "autoindex")
@@ -223,7 +227,7 @@ void    Parser::parse_directives(std::string const &server_block) {
             continue;
         }
         else if (key == "listen" || key == "server_name" || key == "index" ||
-                    key == "autoindex" || key == "root" ||
+                    key == "autoindex" || key == "root" || key == "keepalive_timeout" ||
                     key == "client_max_body_size" || key == "error_page")
             set_server_directives(key, value, server);
         //invalid directive or other error
@@ -269,7 +273,8 @@ Location    &Parser::parse_location(std::string &location_str, Location &locatio
         }
         else if (key == "root" || key == "alias" || key == "index" || key == "autoindex" ||
                     key == "allow_methods" || key == "client_max_body_size" ||
-                    key == "error_page" || key == "cgi_path" || key == "cgi_ext" || key == "upload_path")
+                    key == "error_page" || key == "cgi_path" || key == "cgi_ext" ||
+                    key == "upload_path" || key == "keepalive_timeout")
             set_location_directives(key, value, location);
         //invalid directive or other error
         else

--- a/Server.hpp
+++ b/Server.hpp
@@ -14,6 +14,8 @@
 # include <cstring>
 # include <errno.h>
 # include <sstream>
+# include <climits>
+
 
 class Location;
 class Listener;
@@ -33,27 +35,27 @@ class Server {
         void    set_listeners(std::string listen);
         void    set_root(std::string root);
         void    set_client_max_body_size(std::string client_max_body_size);
+        void    set_timeout(std::string timeout);
         void    set_autoindex(std::string autoindex);
         void    set_server_name(std::string server_name);
         void    set_index(std::string index);
         void    set_error_page(std::string error_page);
         void    set_location(Location &location);
         void    set_host_port(const std::string &hostPort);
-        // void    set_sock_fd(); //create and bind
 
         //getters
         const std::vector<Listen>&  get_listeners() const;
         std::string&                get_root();
         long                        get_client_max_body_size(); //in bytes
+        int                         get_timeout(); // in seconds
         std::string&                get_autoindex();
         std::vector<std::string>&   get_server_name();
         std::vector<std::string>&   get_index();
         std::map<int, std::string>& get_error_pages();
         std::string                 get_error_page_path(int error_code);
         std::vector<std::string>    get_methods();
-        std::vector<Location>&       get_location();
+        std::vector<Location>&      get_location();
         std::string                 get_host_port();
-        // const std::vector<int>&     get_sock_fd() const;
 
         void    check_port(std::string port);
         void    check_host(std::string host);
@@ -67,14 +69,13 @@ class Server {
         std::vector<Listen>         _listeners;
         std::string                 _root;
         long                        _client_max_body_size;
+        int                         _timeout;
         std::string                 _autoindex;
         std::vector<std::string>    _server_name;
         std::vector<std::string>    _index;
         std::map<int, std::string>  _error_pages;
         std::vector<Location>       _locations;
         std::string                 _host_port;
-
-        // std::vector<int>            _sock_fd;
 };
 
 #endif

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -434,7 +434,7 @@ std::map<std::string, std::vector<char>>   ResponseBuilder::postMultipartBody(st
             if (part_end == std::string::npos)
                 part_end = body_content.size();
             else
-                part_end -= 2;
+                part_end -= 4;
             if (part_end < part_start)
                 throw BadRequestException(); //invalid format
             //add o conteudo no vetor
@@ -480,7 +480,7 @@ std::string  ResponseBuilder::getFileName(std::string& filename, std::string con
         if (!_location.get_root().empty())
             path = _location.get_root() + '/' + _location.get_upload_path() + '/';
         else
-            path = _location.get_alias() + '/' + _location.get_upload_path() + '/';        
+            path = _location.get_alias() + '/';        
     }
     else
         path = _location.get_upload_path() + '/';
@@ -608,7 +608,7 @@ void ResponseBuilder::processDELETE() {
             complete_path = _location.get_alias();
     }
 
-    if (isFile(complete_path)) {
+    if (isFile(complete_path) && access(complete_path.c_str(), F_OK)) {
        if (std::remove(complete_path.c_str()) != 0)
             throw InternalServerErrorException();
     }

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -480,7 +480,7 @@ std::string  ResponseBuilder::getFileName(std::string& filename, std::string con
         if (!_location.get_root().empty())
             path = _location.get_root() + '/' + _location.get_upload_path() + '/';
         else
-            path = _location.get_alias() + '/';        
+            path = _location.get_alias() + '/' + _location.get_upload_path() + '/';
     }
     else
         path = _location.get_upload_path() + '/';


### PR DESCRIPTION
Add variavel _timeout em server e em location para setar a diretiva keepalive_timeout. Caso nao seja setado em .conf, o default é 60 segundos. 
Consertei um erro na postMultipartBody() para setar os bytes exatamente como no arquivo original pq antes estava adicionando "/r/n" no final do arquivo.