### PR TITLE
Refactor/webserverreview

### DIFF
--- a/src/core/WebServer.cpp
+++ b/src/core/WebServer.cpp
@@ -231,7 +231,6 @@ void WebServer::acceptConnection(int *serverFd)
 	{
         _conections[newSockFD] = it->second;
 		_requests[newSockFD] = new std::string();
-		modifyEpoll(it->first, EPOLLIN | EPOLLET);
 	}
 	else
 	{
@@ -315,7 +314,10 @@ void WebServer::handleConnections()
 
 			int isServerFD = isServerFDCheck(events[i].data.fd);
 			if (isServerFD != -1)
+			{
 				acceptConnection(&isServerFD);
+				modifyEpoll(fd, EPOLLIN | EPOLLET);
+			}
 			else
 			{
 				if (events[i].events & EPOLLRDHUP)

--- a/src/core/WebServer.cpp
+++ b/src/core/WebServer.cpp
@@ -68,7 +68,7 @@ void WebServer::handleSignal(int param) {
 	Logger::log(LOG_INFO, "Signal received, stopping server...");
 }
 
-Server WebServer::delegateRequest(std::vector<Server> candidateServers, std::string host) {
+Server WebServer::delegateServer(std::vector<Server> candidateServers, std::string host) {
 	for (std::vector<Server>::iterator itServer = candidateServers.begin(); itServer != candidateServers.end(); ++itServer) {
 		std::vector<std::string> servernames = itServer->get_server_name();
 		for (std::vector<std::string>::iterator itServerName = servernames.begin(); itServerName != servernames.end(); ++itServerName) {
@@ -158,6 +158,14 @@ void WebServer::settingListeners() {
 	}
 }
 
+void WebServer::addToEpollServers(){
+	std::map<int, std::vector<Server>>::const_iterator it = this->_fdToServers.begin();
+	for (it; it != this->_fdToServers.end(); ++it)
+	{
+		addToEpoll(it->first, EPOLLIN | EPOLLET);
+	}
+}
+
 void WebServer::addToEpoll(const int &fd, uint32_t events) {
 	struct epoll_event event;
 	event.data.fd = fd;
@@ -181,24 +189,6 @@ void WebServer::modifyEpoll(const int &fd, uint32_t events) {
 	}
 }
 
-void WebServer::addToEpollServers(){
-	std::map<int, std::vector<Server>>::const_iterator it = this->_fdToServers.begin();
-	for (it; it != this->_fdToServers.end(); ++it)
-	{
-		addToEpoll(it->first, EPOLLIN | EPOLLET);
-	}
-}
-
-int WebServer::isServerFDCheck(const int &i) const {
-	std::map<int, std::vector<Server>>::const_iterator it = this->_fdToServers.begin();
-	for (it; it != this->_fdToServers.end(); ++it)
-	{
-		if ( i == it->first)
-			return (it->first);
-	}
-	return (-1);
-}
-
 void WebServer::acceptConnection(int *serverFd)
 {
 	struct sockaddr_storage peer_addr;
@@ -211,16 +201,13 @@ void WebServer::acceptConnection(int *serverFd)
 		return ;
 	}
 
-	//CHECAR COM A FERNANDA!!!!! Fernanda e Mari: Não deveria chear antes de abrir o socket com accept?
-	// check if total connections is greater than SOMAXCONN
-	int totalConnections = this->_conections.size() + this->_fdToServers.size() + 1000;
+	int totalConnections = this->_conections.size() + this->_fdToServers.size() + 2048;
 	if (totalConnections >= SOMAXCONN)
 	{
 		if (newSockFD != -1)
 		{
-			Logger::log(LOG_WARNING, "Max connections reached, closing connection...");
-			Response response;
-			response.loadDefaultErrorPage(503);
+			Logger::log(LOG_ERROR, "Max connections reached, closing connection fd: " + std::to_string(newSockFD));
+			sendErrorResponse(503, newSockFD, _fdToServers[*serverFd][0]);
 			close(newSockFD);
 		}
 		return ;
@@ -229,14 +216,13 @@ void WebServer::acceptConnection(int *serverFd)
 	std::map<int, std::vector<Server>>::iterator it = this->_fdToServers.find(*serverFd);
 	if (it != this->_fdToServers.end())
 	{
-        _conections[newSockFD] = it->second;
+		_conections[newSockFD] = it->second;
 		_requests[newSockFD] = new std::string();
 	}
 	else
 	{
 		Logger::log(LOG_ERROR, "Server socket fd not found!");
-		Response response;
-		response.loadDefaultErrorPage(503);
+		sendErrorResponse(503, newSockFD, _fdToServers[*serverFd][0]);
 		close(newSockFD);
 		return ;
 	}
@@ -282,6 +268,25 @@ void WebServer::clearRequests(const int &fd)
 	}
 }
 
+void WebServer::sendErrorResponse(const int &statusCode, const int &fd, const Server &server)
+{
+	Response response;
+	response.loadErrorPage(statusCode, server, true);
+	std::vector<char> responseContent;
+	responseContent = response.getResponse();
+	write(fd, responseContent.data(), responseContent.size());
+}
+
+int WebServer::isServerFDCheck(const int &i) const {
+	std::map<int, std::vector<Server>>::const_iterator it = this->_fdToServers.begin();
+	for (it; it != this->_fdToServers.end(); ++it)
+	{
+		if ( i == it->first)
+			return (it->first);
+	}
+	return (-1);
+}
+
 int WebServer::ifResGetCGIKey(const int &fd)
 {
 	std::map<int, HandleCGI*>::const_iterator it = _requestsCGI.begin();
@@ -305,8 +310,10 @@ void WebServer::handleConnections()
 			break;
 
 		if (totalFD == -1)
-			throw std::runtime_error("epoll_wait() failure");
-
+		{
+			Logger::log(LOG_ERROR, "epoll_wait() failure");
+			continue ;
+		}
 
 		for (int i = 0; i < totalFD; i++)
 		{
@@ -335,12 +342,11 @@ void WebServer::handleConnections()
 
 						while (true)
 						{
-
 							ssize_t bread = read(cgiH._pipefd[0], buf, BUF_SIZE);
 							if (bread == 0)
 							{
 								closeCGIPipe(cgiH._pipefd[0], "EOF reached. Closing pipe fd: " + std::to_string(cgiH._pipefd[0]));
-                                cgiH.responseReady = 1;
+								cgiH.responseReady = 1;
 								break ;
 							}
 							else if (bread < 0)
@@ -389,7 +395,7 @@ void WebServer::handleConnections()
 							httpRequest req = RequestParser::parseRequest(*_requests[fd]);
 							if (req.request_status == "complete")
 							{
-								modifyEpoll(fd, EPOLLOUT );
+								modifyEpoll(fd, EPOLLOUT);
 							}
 						}
 					}
@@ -420,65 +426,59 @@ void WebServer::handleConnections()
 						if (_requests.find(fd) != _requests.end())
 						{
 							httpRequest req = RequestParser::parseRequest(*_requests[fd]);
-							//check if request is complete and if so, check if it is CGI or STATIC
-							if (req.request_status == "complete")
+							if (req.type == "CGI")
 							{
-								//check if request is CGI or STATIC
-								if (req.type == "CGI")
-								{
-									Logger::log(LOG_WARNING, "CGI Request RECEIVED. Handling..." );
+								Logger::log(LOG_WARNING, "CGI Request RECEIVED. Handling..." );
 
-									HandleCGI *cgiHandler = new HandleCGI(req, this->_epollFD, events[i].data.fd, delegateRequest(_conections[events[i].data.fd], req.host));
-									int fdPipe = cgiHandler->executeCGI();
+								HandleCGI *cgiHandler = new HandleCGI(req, this->_epollFD, events[i].data.fd, delegateServer(_conections[events[i].data.fd], req.host));
+								int fdPipe = cgiHandler->executeCGI();
 
-									if (fdPipe == -1)
-									{
-										closeConnection(fd, "CGI script failed to execute. Closing connection: " + std::to_string(fd));
-										delete cgiHandler;
-									}
-									else {
-										_requestsCGI[fdPipe] = cgiHandler;
-										continue;
-									}
-								}
-								if (req.type == "STATIC")
+								if (fdPipe == -1)
 								{
-									ResponseBuilder response;
-									response.buildResponse(delegateRequest(_conections[events[i].data.fd], req.host), req);
-									std::vector<char> responseString = response.getResponse();
-									size_t wbytes = write(events[i].data.fd, responseString.data(), responseString.size());
-									if (wbytes == 0)
-									{
-										Logger::log(LOG_ERROR, "write() failure, response not sent.");
-									}
-									else if (wbytes < responseString.size())
-									{
-										Logger::log(LOG_ERROR, "write() failure, response not sent completely.");
-									}
-									else
-									{
-										Logger::log(LOG_INFO, "Response sent successfully.");
-									}
-										closeConnection(fd, "Closing connection: " + std::to_string(fd));
+									closeConnection(fd, "CGI script failed to execute. Closing connection: " + std::to_string(fd));
+									delete cgiHandler;
 								}
+								else {
+									_requestsCGI[fdPipe] = cgiHandler;
+									continue;
+								}
+							}
+							if (req.type == "STATIC")
+							{
+								ResponseBuilder response;
+								response.buildResponse(delegateServer(_conections[events[i].data.fd], req.host), req);
+								std::vector<char> responseString = response.getResponse();
+								size_t wbytes = write(events[i].data.fd, responseString.data(), responseString.size());
+								if (wbytes == 0)
+								{
+									Logger::log(LOG_ERROR, "write() failure, response not sent.");
+								}
+								else if (wbytes < responseString.size())
+								{
+									Logger::log(LOG_ERROR, "write() failure, response not sent completely.");
+								}
+								else
+								{
+									Logger::log(LOG_INFO, "Response sent successfully.");
+								}
+									closeConnection(fd, "Closing connection: " + std::to_string(fd));
 							}
 						}
 					}
 				}
-                else if ((events[i].events & EPOLLHUP) && (_requestsCGI.find(fd) != _requestsCGI.end()))
-                {
+				else if ((events[i].events & EPOLLHUP) && (_requestsCGI.find(fd) != _requestsCGI.end()))
+				{
 					char buf[BUF_SIZE];
 					memset(buf, 0, BUF_SIZE);
-                    HandleCGI &cgiH = *_requestsCGI[fd];
-                    ssize_t bread = read(cgiH._pipefd[0], buf, BUF_SIZE);
-                    if (bread == 0)
+					HandleCGI &cgiH = *_requestsCGI[fd];
+					ssize_t bread = read(cgiH._pipefd[0], buf, BUF_SIZE);
+					if (bread == 0)
 						cgiH.responseReady = 1;
-                }
+				}
 			}
 		}
 	}
 }
-
 
 void WebServer::run() {
 	this->_epollFD = epoll_create1(0);

--- a/src/core/WebServer.hpp
+++ b/src/core/WebServer.hpp
@@ -19,38 +19,42 @@ class Logger;
 
 class WebServer {
 	private:
-		int					_epollFD;
-		std::map<int, std::vector<Server>> _fdToServers;
-		std::map<int, std::vector<Server>> _conections;
-		std::map<int, HandleCGI*> _requestsCGI;
-		std::map<int, std::string*> _requests;
-		static bool				isRunning;
+		int									_epollFD;
+		std::map<int, std::vector<Server>>	_fdToServers;
+		std::map<int, std::vector<Server>>	_conections;
+		std::map<int, HandleCGI*>			_requestsCGI;
+		std::map<int, std::string*>			_requests;
+		static bool							isRunning;
 
 		WebServer();
 
-		void	creatingAndBinding(const std::map<std::string, std::vector<Server>> &groupServers);
-		void	settingListeners();
-		void	addToEpollServers( );
-		void	addToEpoll(const int &fd, uint32_t events);
-		void	modifyEpoll(const int &fd, uint32_t events);
-		void	acceptConnection(int *serverFd);
-		void	handleConnections( );
-		void 	closeConnection(const int &fd, std::string message);
-		void 	closeCGIPipe(const int &fd, std::string message);
-		void 	clearCGIRequests(const int &fd);
-		void 	clearRequests(const int &fd);
-		int		ifResGetCGIKey(const int &fd);
-
-		int		isServerFDCheck(const int &i) const;
-		Server	delegateRequest(std::vector<Server> candidateServers, std::string host);
-
 		static void	handleSignal(int param);
+
+		Server		delegateServer(std::vector<Server> candidateServers, std::string host);
+
+		void		creatingAndBinding(const std::map<std::string, std::vector<Server>> &groupServers);
+		void		settingListeners( );
+		void		addToEpollServers( );
+		void		addToEpoll(const int &fd, uint32_t events);
+		void		modifyEpoll(const int &fd, uint32_t events);
+		void		acceptConnection(int *serverFd);
+		void 		closeConnection(const int &fd, std::string message);
+		void 		closeCGIPipe(const int &fd, std::string message);
+		void 		clearCGIRequests(const int &fd);
+		void 		clearRequests(const int &fd);
+		void		sendErrorResponse(const int &statusCode, const int &fd, const Server &server);
+		void		handleConnections( );
+
+		int			isServerFDCheck(const int &i) const;
+		int			ifResGetCGIKey(const int &fd);
+
+
 
 	public:
 		WebServer(const std::vector<Server> &parsedServers);
 		~WebServer();
 
-		void run();
+		void 		run();
 
 };
 

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -217,42 +217,77 @@ void Response::loadErrorPage(int statusCode, Server server, bool logError) {
     loadFromFile(error_page_full_path);
 }
 
+void Response::setDefaultErrorPage(int statusCode, const std::string &title) {
+    std::ostringstream oss;
+    oss << "HTTP/1.1 " << statusCode << " " << title << "\r\n";
+    std::string statusMessage = oss.str();
+
+    oss.str("");
+    oss << "<!DOCTYPE html>";
+    oss << "<html lang='en'>";
+    oss << "<head>";
+    oss << "<meta charset='UTF-8'>";
+    oss << "<meta name='viewport' content='width=device-width, initial-scale=1.0'>";
+    oss << "<title>" << statusCode << " " << title <<"</title>";
+    oss << "<style>";
+    oss << "body { font-family: Arial, sans-serif; text-align: center; margin-top: 50px; }";
+    oss << "h1 { font-size: 100px; }";
+    oss << "p { font-size: 20px; }";
+    oss << "</style>";
+    oss << "</head>";
+    oss << "<body>";
+    oss << "<h1>" << statusCode << "</h1>";
+    oss << "<p>" << title << "</p>";
+    oss << "<p>by Fe, Iza e Mari</p>";
+    oss << "</body>";
+    oss << "</html>";
+
+    std::string responseContent = oss.str();
+
+    oss.str("");
+
+    oss << "Content-Type: text/html\r\nContent-Length:" << responseContent.size() << " \r\n\r\n";
+    std::string header = oss.str();
+
+    setStatusMessage(statusMessage);
+    setHttpHeaders(header);
+    setResponseContent(responseContent);
+}
+
 void Response::loadDefaultErrorPage(int statusCode) {
     switch (statusCode) {
         case 400:
-            setStatusMessage(STATUS_400);
-            setHttpHeaders(HEADER_400);
-            setResponseContent(HTML_400);
+            setDefaultErrorPage(400, "Bad Request");
+            break;
+        case 401:
+            setDefaultErrorPage(401, "Unauthorized");
             break;
         case 403:
-            setStatusMessage(STATUS_403);
-            setHttpHeaders(HEADER_403);
-            setResponseContent(HTML_403);
+            setDefaultErrorPage(403, "Forbidden");
             break;
         case 404:
-            setStatusMessage(STATUS_404);
-            setHttpHeaders(HEADER_404);
-            setResponseContent(HTML_404);
+            setDefaultErrorPage(404, "Not Found");
             break;
         case 405:
-            setStatusMessage(STATUS_405);
-            setHttpHeaders(HEADER_405);
-            setResponseContent(HTML_405);
+            setDefaultErrorPage(405, "Method Not Allowed");
             break;
         case 413:
-            setStatusMessage(STATUS_413);
-            setHttpHeaders(HEADER_413);
-            setResponseContent(HTML_413);
+            setDefaultErrorPage(413, "Request Entity Too Large");
+            break;
+        case 500:
+            setDefaultErrorPage(500, "Internal Server Error");
+            break;
+        case 501:
+            setDefaultErrorPage(501, "Not Implemented");
+            break;
+        case 502:
+            setDefaultErrorPage(502, "Bad Gateway");
             break;
         case 503:
-            setStatusMessage(STATUS_503);
-            setHttpHeaders(HEADER_503);
-            setResponseContent(HTML_503);
+            setDefaultErrorPage(503, "Service Unavailable");
             break;
         default:
-            setStatusMessage(STATUS_500);
-            setHttpHeaders(HEADER_500);
-            setResponseContent(HTML_500);
+            setDefaultErrorPage(500, "Internal Server Error");
             break;
     }
 }

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -101,7 +101,7 @@ void Response::loadAutoIndex(std::string &path, std::string &request_path) {
         currentDir = request_path + "/";
     else
         currentDir = "/" + request_path + "/";
-    
+
     std::string autoIndex = "<html><head><title>Index</title>";
     autoIndex += "<style>table { border-collapse: collapse; } th, td { padding: 10px; }</style>";
     autoIndex += "</head><body><h1>Index of " + currentDir + "</h1>";
@@ -243,6 +243,11 @@ void Response::loadDefaultErrorPage(int statusCode) {
             setStatusMessage(STATUS_413);
             setHttpHeaders(HEADER_413);
             setResponseContent(HTML_413);
+            break;
+        case 503:
+            setStatusMessage(STATUS_503);
+            setHttpHeaders(HEADER_503);
+            setResponseContent(HTML_503);
             break;
         default:
             setStatusMessage(STATUS_500);

--- a/src/http/Response.hpp
+++ b/src/http/Response.hpp
@@ -33,6 +33,7 @@ class Response {
         void loadAutoIndex(std::string &path, std::string &request_path);
         void loadErrorPage(int statusCode, Server server, bool logError = true);
         void loadDefaultErrorPage(int statusCode);
+        void setDefaultErrorPage(int statusCode, const std::string &message);
         const std::vector<char> getResponse() const;
         int getResponseSize() const;
 

--- a/src/server_local.conf
+++ b/src/server_local.conf
@@ -2,7 +2,7 @@ server {
     listen 127.0.0.1:8042;
     server_name www.default.com;
 
-    root /home/42/webserv/webserver/www/data/default;
+    root /home/iza/Documents/webserver/www/data/default;
 
     autoindex on;
 
@@ -17,7 +17,7 @@ server {
     listen 127.0.0.1:8042;
     server_name www.webserv42.com;
 
-    root /home/42/webserv/webserver/www/data/webserv42.com;
+    root /home/iza/Documents/webserver/www/data/webserv42.com;
 
     index home.html;
 
@@ -29,7 +29,7 @@ server {
     }
 
     location /about {
-        alias /home/42/webserv/webserver/www/data/webserv42.com/about_page;
+        alias /home/iza/Documents/webserver/www/data/webserv42.com/about_page;
     }
 
     location /juninho {
@@ -40,7 +40,7 @@ server {
     location /upload {
         index upload.html;
         allow_methods GET POST DELETE;
-        upload_path /home/42/webserv/webserver/www/data/webserv42.com/upload;
+        upload_path /home/iza/upload;
         client_max_body_size 10m;
     }
 
@@ -56,7 +56,7 @@ server {
 
     server_name www.webserv42.com www.anotherserver.com;
 
-    root /home/42/webserv/webserver/www/data/anotherserver.com;
+    root /home/iza/Documents/webserver/www/data/anotherserver.com;
 
     autoindex on;
 
@@ -68,11 +68,11 @@ server {
     }
 
     location /timer-cgi {
-        cgi_path /home/42/webserv/webserver/www/cgi-bin;
+        cgi_path /home/iza/Documents/webserver/www/cgi-bin;
     }
 
     location /feed {
-        cgi_path /home/42/webserv/webserver/www/cgi-bin/feed;
+        cgi_path /home/iza/Documents/webserver/www/cgi-bin/feed;
         autoindex on;
     }
 
@@ -86,7 +86,7 @@ server {
     listen 127.0.0.1:4280;
     server_name www.port8000first.com;
 
-    root /home/42/webserv/webserver/www/data/port8000first.com;
+    root /home/iza/Documents/webserver/www/data/port8000first.com;
 
     error_page 403 /error_pages/403.html;
     error_page 404 /error_pages/404.html;
@@ -99,7 +99,7 @@ server {
     listen 127.0.0.1:4280;
     server_name www.port8000second.com;
 
-    root /home/42/webserv/webserver/www/data/port8000second.com;
+    root /home/iza/Documents/webserver/www/data/port8000second.com;
 
     error_page 403 /error_pages/403.html;
     error_page 404 /error_pages/404.html;

--- a/src/server_local.conf
+++ b/src/server_local.conf
@@ -4,11 +4,10 @@ server {
 
     root /home/iza/Documents/webserver/www/data/default;
 
-    autoindex on;
+    autoindex off;
 
     error_page 403 /error_pages/403.html;
     error_page 404 /error_pages/404.html;
-
 
 }
 

--- a/src/server_local.conf
+++ b/src/server_local.conf
@@ -12,6 +12,18 @@ server {
 
 }
 
+server {
+    listen [::1]:8042;
+    server_name www.default6.com;
+
+    root /home/iza/Documents/webserver/www/data/default;
+
+    autoindex on;
+
+    error_page 403 /error_pages/403.html;
+    error_page 404 /error_pages/404.html;
+}
+
 
 server {
     listen 127.0.0.1:8042;
@@ -81,7 +93,6 @@ server {
 
 }
 
-
 server {
     listen 127.0.0.1:4280;
     server_name www.port8000first.com;
@@ -93,7 +104,6 @@ server {
 
 
 }
-
 
 server {
     listen 127.0.0.1:4280;

--- a/test/monitor.sh
+++ b/test/monitor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 URL="http://localhost:8042/"
-DURATION="5S"
+DURATION="60S"
 CONCURRENT_USERS=10
 MEMORY_THRESHOLD_PERCENT=5  # Adjust as needed (represents 5% of total memory)
 CHECK_INTERVAL=10  # in seconds


### PR DESCRIPTION
Fala pessoal:
- arrumei aonde tinha colocado o reset do epoll do fd do socket, estava em accept apenas quando estivesse erro, mas na verdade tem que estar no loop principal de handleconnection, para toda vez que ocorre um evento no socket de listen.
- revisei toda a webserver e arrumei o envio de resposta apropriado quando dá erro em accept
- passei testes, veriquei leaks.
- criei o metodo setDefaultErrorPage, assim não precisamos ficar criando na mão em error_pages.hpp. Se precisar de mais algum método, basta adicionar no switch case de loadDefaultErrorPage, passando o código do erro e o título do erro. Ainda mantive a pagina error_pages para conferencia, mas fiz testes por aqui e tava de boa.
- também criei um server (configurações) com endereço ipv6 - só pra confirmar que estava valido tbm